### PR TITLE
Bump NodeJS image from v4.6.2 to v6.11.3

### DIFF
--- a/agent/image.yaml
+++ b/agent/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.0
 name: rh-amqmaas-1/amqmaas10-agent-openshift
 description: "AMQMaas console"
-from: rhscl/nodejs-4-rhel7:latest
+from: rhscl/nodejs-6-rhel7:latest
 labels:
     - name: "com.redhat.component"
       value: "amqmaas-1-amqmaas10-agent-openshift-container"

--- a/agent/modules/platform/rhel/agent/added/launch_node.sh
+++ b/agent/modules/platform/rhel/agent/added/launch_node.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-. /opt/rh/rh-nodejs4/enable
+. /opt/rh/rh-nodejs6/enable
 
 node $1


### PR DESCRIPTION
Required for 0.23.0 owing Agent's use of Array.includes().