### PR TITLE
Add license metadata to image at prescribed location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/target
+openshift.local.clusterup

--- a/Makefile.common
+++ b/Makefile.common
@@ -30,6 +30,6 @@ copyartifact:
 	cp $(ABSOLUTE_LOCAL_ARTIFACT_DIR) $(NEW_ABSOLUTE_LOCAL_ARTIFACT)
 
 clean:
-	rm -rf build
+	rm -rf build target
 
 .PHONY: all push snapshot clean

--- a/address-space-controller/modules/common/licenses.sh
+++ b/address-space-controller/modules/common/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/address-space-controller.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/address-space-controller/modules/common/module.yaml
+++ b/address-space-controller/modules/common/module.yaml
@@ -4,4 +4,5 @@ name: addresscontroller.common
 version: '1.0'
 
 execute:
+    - script: licenses.sh
     - script: install.sh

--- a/agent/modules/platform/rhel/agent/licenses.sh
+++ b/agent/modules/platform/rhel/agent/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/agent-dist.zip" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/agent/modules/platform/rhel/agent/module.yaml
+++ b/agent/modules/platform/rhel/agent/module.yaml
@@ -3,4 +3,5 @@ schema_version: 1
 name: agent
 version: '1.0'
 execute:
+  - script: licenses.sh
   - script: install.sh

--- a/api-server/modules/common/licenses.sh
+++ b/api-server/modules/common/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/api-server.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/api-server/modules/common/module.yaml
+++ b/api-server/modules/common/module.yaml
@@ -4,4 +4,5 @@ name: apiserver.common
 version: '1.0'
 
 execute:
+    - script: licenses.sh
     - script: install.sh

--- a/auth-controller/modules/keycloak-controller/licenses.sh
+++ b/auth-controller/modules/keycloak-controller/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/keycloak-controller.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/auth-controller/modules/keycloak-controller/module.yaml
+++ b/auth-controller/modules/keycloak-controller/module.yaml
@@ -3,4 +3,5 @@ schema_version: 1
 name: keycloak-controller
 version: '1.0'
 execute:
+  - script: licenses.sh
   - script: install.sh

--- a/auth-plugin/modules/auth.rhel.install/licenses.sh
+++ b/auth-plugin/modules/auth.rhel.install/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/sasl-plugin.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/auth-plugin/modules/auth.rhel.install/module.yaml
+++ b/auth-plugin/modules/auth.rhel.install/module.yaml
@@ -4,4 +4,5 @@ name: auth.rhel.install
 version: '1.0'
 
 execute:
+  - script: licenses.sh
   - script: install.sh

--- a/broker-plugin/modules/broker-plugin-installer/licenses.sh
+++ b/broker-plugin/modules/broker-plugin-installer/licenses.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+SOURCES_DIR=/tmp/artifacts/
+
+for jar in amqp-connector sasl-delegation jmx-exporter
+do
+    LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}/${jar}
+    mkdir -p ${LICENSE_DIR}
+    unzip -nj "$SOURCES_DIR/${jar}.jar" 'licenses/*' -d ${LICENSE_DIR}
+done
+

--- a/broker-plugin/modules/broker-plugin-installer/module.yaml
+++ b/broker-plugin/modules/broker-plugin-installer/module.yaml
@@ -4,4 +4,5 @@ name: broker.plugin.installer
 version: '1.0'
 
 execute:
+  - script: licenses.sh
   - script: install.sh

--- a/mqtt-gateway/modules/mqtt-gateway/licenses.sh
+++ b/mqtt-gateway/modules/mqtt-gateway/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/mqtt-gateway.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/mqtt-gateway/modules/mqtt-gateway/module.yaml
+++ b/mqtt-gateway/modules/mqtt-gateway/module.yaml
@@ -3,4 +3,5 @@ schema_version: 1
 name: mqtt-gateway
 version: '1.0'
 execute:
+  - script: licenses.sh
   - script: install.sh

--- a/mqtt-lwt/modules/mqtt-lwt/licenses.sh
+++ b/mqtt-lwt/modules/mqtt-lwt/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/mqtt-lwt.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/mqtt-lwt/modules/mqtt-lwt/module.yaml
+++ b/mqtt-lwt/modules/mqtt-lwt/module.yaml
@@ -3,4 +3,5 @@ schema_version: 1
 name: mqtt-lwt
 version: '1.0'
 execute:
+  - script: licenses.sh
   - script: install.sh

--- a/service-broker/modules/common/licenses.sh
+++ b/service-broker/modules/common/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/service-broker.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/service-broker/modules/common/module.yaml
+++ b/service-broker/modules/common/module.yaml
@@ -4,4 +4,5 @@ name: servicebroker.common
 version: '1.0'
 
 execute:
+    - script: licenses.sh
     - script: install.sh

--- a/standard-controller/modules/common/licenses.sh
+++ b/standard-controller/modules/common/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/standard-controller.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/standard-controller/modules/common/module.yaml
+++ b/standard-controller/modules/common/module.yaml
@@ -4,4 +4,5 @@ name: standardcontroller.common
 version: '1.0'
 
 execute:
+    - script: licenses.sh
     - script: install.sh

--- a/topic-forwarder/modules/topic-forwarder/licenses.sh
+++ b/topic-forwarder/modules/topic-forwarder/licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PRODUCT_IDENTIFIER=$(echo ${JBOSS_IMAGE_NAME} | awk -F'/' '{print $2}')
+LICENSE_DIR=/root/licenses/${PRODUCT_IDENTIFIER}
+SOURCES_DIR=/tmp/artifacts/
+
+mkdir -p ${LICENSE_DIR}
+unzip -nj "$SOURCES_DIR/topic-forwarder.jar" 'licenses/*' -d ${LICENSE_DIR}
+

--- a/topic-forwarder/modules/topic-forwarder/module.yaml
+++ b/topic-forwarder/modules/topic-forwarder/module.yaml
@@ -3,4 +3,5 @@ schema_version: 1
 name: topic-forwarder
 version: '1.0'
 execute:
+  - script: licenses.sh
   - script: install.sh


### PR DESCRIPTION
This change will include the artefact's license metadata, html report and license text files in the prescribed location in the image, like this:

```
/root/licenses
/root/licenses/amqmaas10-api-server-openshift
/root/licenses/amqmaas10-api-server-openshift/apache 2.0 - license-2.0.txt
/root/licenses/amqmaas10-api-server-openshift/mit license - mit-license.php
/root/licenses/amqmaas10-api-server-openshift/bsd - bsd-license.php
/root/licenses/amqmaas10-api-server-openshift/gnu general public license, version 2 with the classpath exception - gpl-2.0-ce.txt
/root/licenses/amqmaas10-api-server-openshift/lgplv3 or later - lgpl.html
```

This PR only applies the change to api-server at the minute.  Once reviewed, I'll use the same techniques on the others.  Unfortunately I don't see a way to avoid the duplication of the script and the config within module.yaml.