### PR TITLE
Guard against old Node interpreter / Allow options to be passed to the NodeJS command line for convenient remote debugging

### DIFF
--- a/agent/modules/platform/rhel/agent/added/launch_node.sh
+++ b/agent/modules/platform/rhel/agent/added/launch_node.sh
@@ -1,5 +1,19 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . /opt/rh/rh-nodejs6/enable
 
-node $1
+# Ensure that we have a suitable node interpreter.  This ought to be declared declaratively in the package.json, within an engines section,
+# but we currently don't install the package so this wouldn't be enforced.
+REQUIRED_NODE_MAJOR=6
+NODE_MAJOR=$(node -p 'process.version.match("^v?(\\d+)\.")[1]')
+if [[ ${NODE_MAJOR} -lt ${REQUIRED_NODE_MAJOR} ]]; then
+    2>&1 echo "Node major version ${NODE_MAJOR} [$(node --version)] too low - require ${REQUIRED_NODE_MAJOR}"
+    exit 1
+fi
+
+if [[ ! -z "${_NODE_OPTIONS}" ]]; then
+    set -- ${_NODE_OPTIONS} "${@}"
+fi
+
+node "${@}"
+


### PR DESCRIPTION
Guard against old Node interpreter (#1774)
Allow options to be passed to the NodeJS command line for convenient remote debugging. (#1769)

Cherry picked changes from e3f4d442e2/75eb96f605e4 respectively