### PR TITLE
Remove our dependency on the CE cacher

### DIFF
--- a/address-space-controller/image-template.yaml
+++ b/address-space-controller/image-template.yaml
@@ -38,14 +38,14 @@ modules:
           - name: common.java
 
 packages:
-    repositories:
-        - jboss-os
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
         - openssl
 
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: address-space-controller.zip
 
 run:
@@ -54,6 +54,10 @@ run:
           - "/bin/launch_java.sh"
           - "/opt/address-space-controller.jar"
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-address-space-controller-rhel-7

--- a/address-space-controller/image.yaml
+++ b/address-space-controller/image.yaml
@@ -19,6 +19,12 @@ envs:
       value: "0.25.0.redhat-00061"
     - name: "LOG_LEVEL"
       value: "info"
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+    install:
+        - openssl
 
 modules:
       repositories:
@@ -37,15 +43,8 @@ modules:
           - name: addresscontroller.common
           - name: common.java
 
-packages:
-    repositories:
-        - jboss-os
-    install:
-        - openssl
-
 artifacts:
-    - path: address-space-controller-0.25.0.redhat-00061-dist.zip
-      md5: 99f4f6487cf071f2ac00913d5c8d06e3
+    - md5: 99f4f6487cf071f2ac00913d5c8d06e3
       name: address-space-controller.zip
 
 run:
@@ -54,6 +53,10 @@ run:
           - "/bin/launch_java.sh"
           - "/opt/address-space-controller.jar"
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-address-space-controller-rhel-7

--- a/agent/image-template.yaml
+++ b/agent/image-template.yaml
@@ -26,8 +26,7 @@ modules:
           - name: agent
 
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: agent-dist.zip
 
 ports:
@@ -41,6 +40,10 @@ run:
           - "/opt/app-root/src/bin/agent.js"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-agent-rhel-7

--- a/agent/image.yaml
+++ b/agent/image.yaml
@@ -26,8 +26,7 @@ modules:
           - name: agent
 
 artifacts:
-    - path: agent-0.25.0.redhat-00061-dist.zip
-      md5: 8a2be6a548fdfd4b4371bea01e7734a1
+    - md5: 8a2be6a548fdfd4b4371bea01e7734a1
       name: agent-dist.zip
 
 ports:
@@ -41,6 +40,10 @@ run:
           - "/opt/app-root/src/bin/agent.js"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-agent-rhel-7

--- a/api-server/image-template.yaml
+++ b/api-server/image-template.yaml
@@ -37,9 +37,13 @@ modules:
           - name: apiserver.common
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: api-server.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/opt/api-server.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-api-server-rhel-7

--- a/api-server/image.yaml
+++ b/api-server/image.yaml
@@ -37,9 +37,13 @@ modules:
           - name: apiserver.common
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: api-server-0.25.0.redhat-00061.jar
-      md5: 5719adb49473e68114f575571e95bd7a
+    - md5: 5719adb49473e68114f575571e95bd7a
       name: api-server.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/opt/api-server.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-api-server-rhel-7

--- a/auth-controller/image-template.yaml
+++ b/auth-controller/image-template.yaml
@@ -37,9 +37,13 @@ modules:
           - name: common.java
           - name: keycloak-controller
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: keycloak-controller.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/opt/keycloak-controller.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-auth-controller-rhel-7

--- a/auth-controller/image.yaml
+++ b/auth-controller/image.yaml
@@ -37,9 +37,13 @@ modules:
           - name: common.java
           - name: keycloak-controller
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: keycloak-controller-0.25.0.redhat-00061.jar
-      md5: 9efebce6f7cbe9eb3a1f9183e2d0031f
+    - md5: 9efebce6f7cbe9eb3a1f9183e2d0031f
       name: keycloak-controller.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/opt/keycloak-controller.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-auth-controller-rhel-7

--- a/auth-plugin/image-template.yaml
+++ b/auth-plugin/image-template.yaml
@@ -47,9 +47,13 @@ modules:
           - name: auth.rhel.install
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: sasl-plugin.jar
 
 run:
@@ -58,6 +62,10 @@ run:
           - "/keycloak-plugin/bin/init-keycloak.sh"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-auth-plugin-rhel-7

--- a/auth-plugin/image.yaml
+++ b/auth-plugin/image.yaml
@@ -25,10 +25,11 @@ envs:
       value: "-Dvertx.cacheDirBase=/tmp -Djboss.bind.address=0.0.0.0 -Djava.net.preferIPv4Stack=true"
 
 packages:
-    repositories:
-      - jboss-os
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
-      - openssl
+        - openssl
 
 modules:
       repositories:
@@ -48,8 +49,7 @@ modules:
           - name: common.java
 
 artifacts:
-    - path: sasl-plugin-0.25.0.redhat-00061.jar
-      md5: a73bb8f2c156eddb5d10595ef009dddc
+    - md5: a73bb8f2c156eddb5d10595ef009dddc
       name: sasl-plugin.jar
 
 run:
@@ -58,6 +58,10 @@ run:
           - "/keycloak-plugin/bin/init-keycloak.sh"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-auth-plugin-rhel-7

--- a/broker-plugin/image-template.yaml
+++ b/broker-plugin/image-template.yaml
@@ -23,11 +23,9 @@ envs:
       value: "info"
 
 packages:
-    repositories:
-        - jboss-os
-# Need to switch the repository definition to, and have an override for building on fedora:
-#       - name: OS
-#         id: rhel-server-os-7-rpms
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
         - python
         - gettext
@@ -51,17 +49,13 @@ modules:
           - name: os-java-run
 
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: broker-plugin.zip
-    - path: jmx_prometheus_javaagent-0.10.0.redhat-2.jar
-      md5: 89e83b40f70c9ca43a409e5b485555bc
+    - md5: 89e83b40f70c9ca43a409e5b485555bc
       name: jmx-exporter.jar
-    - path: netty-tcnative-boringssl-static-2.0.7.Final.jar
-      md5: 5da2f900047b0a53bf526dd9f37d4ffd
+    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
       name: netty-tcnative-boringssl-static.jar
-    - path: netty-tcnative-boringssl-static-2.0.7.Final-linux-x86_64.jar
-      md5: f9410ba141f63cff9202149efc321657
+    - md5: f9410ba141f63cff9202149efc321657
       name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:
@@ -70,6 +64,10 @@ run:
           - "/opt/broker-plugin/bin/init-broker.sh"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-broker-plugin-rhel-7

--- a/broker-plugin/image.yaml
+++ b/broker-plugin/image.yaml
@@ -23,11 +23,9 @@ envs:
       value: "info"
 
 packages:
-    repositories:
-        - jboss-os
-# Need to switch the repository definition to, and have an override for building on fedora:
-#       - name: OS
-#         id: rhel-server-os-7-rpms
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
         - python
         - gettext
@@ -51,17 +49,13 @@ modules:
           - name: os-java-run
 
 artifacts:
-    - path: broker-plugin-0.25.0.redhat-00061-dist.zip
-      md5: a2ea126817e4b56e0d26117273fd2794
+    - md5: a2ea126817e4b56e0d26117273fd2794
       name: broker-plugin.zip
-    - path: jmx_prometheus_javaagent-0.10.0.redhat-2.jar
-      md5: 89e83b40f70c9ca43a409e5b485555bc
+    - md5: 89e83b40f70c9ca43a409e5b485555bc
       name: jmx-exporter.jar
-    - path: netty-tcnative-boringssl-static-2.0.7.Final.jar
-      md5: 5da2f900047b0a53bf526dd9f37d4ffd
+    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
       name: netty-tcnative-boringssl-static.jar
-    - path: netty-tcnative-boringssl-static-2.0.7.Final-linux-x86_64.jar
-      md5: f9410ba141f63cff9202149efc321657
+    - md5: f9410ba141f63cff9202149efc321657
       name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:
@@ -70,6 +64,10 @@ run:
           - "/opt/broker-plugin/bin/init-broker.sh"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-broker-plugin-rhel-7

--- a/mqtt-gateway/image-template.yaml
+++ b/mqtt-gateway/image-template.yaml
@@ -50,9 +50,13 @@ modules:
           - name: mqtt-gateway
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: mqtt-gateway.jar
 
 run:
@@ -62,6 +66,10 @@ run:
           - "/opt/mqtt-gateway.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-mqtt-gateway-rhel-7

--- a/mqtt-gateway/image.yaml
+++ b/mqtt-gateway/image.yaml
@@ -50,9 +50,13 @@ modules:
           - name: mqtt-gateway
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: mqtt-gateway-0.25.0.redhat-00061.jar
-      md5: e365c97b7b648eca3744bb414b9fe64d
+    - md5: e365c97b7b648eca3744bb414b9fe64d
       name: mqtt-gateway.jar
 
 run:
@@ -62,6 +66,10 @@ run:
           - "/opt/mqtt-gateway.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-mqtt-gateway-rhel-7

--- a/mqtt-lwt/image-template.yaml
+++ b/mqtt-lwt/image-template.yaml
@@ -37,9 +37,13 @@ modules:
           - name: mqtt-lwt
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: mqtt-lwt.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/mqtt-lwt.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-mqtt-lwt-rhel-7

--- a/mqtt-lwt/image.yaml
+++ b/mqtt-lwt/image.yaml
@@ -37,9 +37,13 @@ modules:
           - name: mqtt-lwt
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: mqtt-lwt-0.25.0.redhat-00061.jar
-      md5: 85e65aa6307f8374183d021b226de574
+    - md5: 85e65aa6307f8374183d021b226de574
       name: mqtt-lwt.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/mqtt-lwt.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-mqtt-lwt-rhel-7

--- a/service-broker/image-template.yaml
+++ b/service-broker/image-template.yaml
@@ -37,9 +37,13 @@ modules:
           - name: servicebroker.common
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: service-broker.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/opt/service-broker.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-service-broker-rhel-7

--- a/service-broker/image.yaml
+++ b/service-broker/image.yaml
@@ -37,9 +37,13 @@ modules:
           - name: servicebroker.common
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: service-broker-0.25.0.redhat-00061.jar
-      md5: bc48abbe61941c533e2a3dfcfad15c37
+    - md5: bc48abbe61941c533e2a3dfcfad15c37
       name: service-broker.jar
 
 run:
@@ -49,6 +53,10 @@ run:
           - "/opt/service-broker.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-service-broker-rhel-7

--- a/standard-controller/image-template.yaml
+++ b/standard-controller/image-template.yaml
@@ -44,8 +44,7 @@ packages:
         - openssl
 
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: standard-controller.jar
 
 run:
@@ -55,6 +54,10 @@ run:
           - "/opt/standard-controller.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-standard-controller-rhel-7

--- a/standard-controller/image.yaml
+++ b/standard-controller/image.yaml
@@ -44,8 +44,7 @@ packages:
         - openssl
 
 artifacts:
-    - path: standard-controller-0.25.0.redhat-00061.jar
-      md5: f8c86358b5064a17b78f069a959a9923
+    - md5: f8c86358b5064a17b78f069a959a9923
       name: standard-controller.jar
 
 run:
@@ -55,6 +54,10 @@ run:
           - "/opt/standard-controller.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-standard-controller-rhel-7

--- a/topic-forwarder/image-template.yaml
+++ b/topic-forwarder/image-template.yaml
@@ -39,9 +39,13 @@ modules:
           - name: topic-forwarder
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: ${ARTIFACT}
-      md5: ${ARTIFACT_MD5}
+    - md5: ${ARTIFACT_MD5}
       name: topic-forwarder.jar
 
 run:
@@ -51,6 +55,10 @@ run:
           - "/topic-forwarder.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-topic-forwarder-rhel-7

--- a/topic-forwarder/image.yaml
+++ b/topic-forwarder/image.yaml
@@ -39,9 +39,13 @@ modules:
           - name: topic-forwarder
           - name: common.java
 
+packages:
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
+
 artifacts:
-    - path: topic-forwarder-0.25.0.redhat-00061.jar
-      md5: ca3c9a5b5de7f8f47056e3c5b82c017d
+    - md5: ca3c9a5b5de7f8f47056e3c5b82c017d
       name: topic-forwarder.jar
 
 run:
@@ -51,6 +55,10 @@ run:
           - "/topic-forwarder.jar"
 
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-topic-forwarder-rhel-7


### PR DESCRIPTION
- add content_sets
- remove path.  It can pull directly from brew from the md5

Signed-off-by: Vanessa <vbusch@redhat.com>