### PR TITLE
Duplicate artifacts

### DIFF
--- a/broker-plugin/image.yaml
+++ b/broker-plugin/image.yaml
@@ -53,9 +53,9 @@ artifacts:
       name: broker-plugin.zip
     - md5: 4f08e57afb4088469904956237c0cf8e
       name: jmx-exporter.jar
-    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
+    - md5: 60f88be0fa76bc2d1b89f71725910441
       name: netty-tcnative-boringssl-static.jar
-    - md5: f9410ba141f63cff9202149efc321657
+    - md5: 937aaba484e64f035cc85239a1e2e184
       name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:

--- a/broker-plugin/image.yaml
+++ b/broker-plugin/image.yaml
@@ -51,12 +51,6 @@ modules:
 artifacts:
     - md5: 74ca83021c132fa2a8973572f8283d3d
       name: broker-plugin.zip
-    - md5: 4f08e57afb4088469904956237c0cf8e
-      name: jmx-exporter.jar
-    - md5: 60f88be0fa76bc2d1b89f71725910441
-      name: netty-tcnative-boringssl-static.jar
-    - md5: 937aaba484e64f035cc85239a1e2e184
-      name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:
       user: 185

--- a/broker-plugin/modules/broker-plugin-installer/install.sh
+++ b/broker-plugin/modules/broker-plugin-installer/install.sh
@@ -8,15 +8,8 @@ BROKER_PLUGIN_DIR=/opt/broker-plugin
 
 {
     mkdir -p ${BROKER_PLUGIN_DIR}/bin
-    mkdir -p ${BROKER_PLUGIN_DIR}/lib
-    mkdir -p ${BROKER_PLUGIN_DIR}/jmx_exporter
 
-	unzip "${SOURCES_DIR}/broker-plugin.zip" -d /
-
-    mv ${SOURCES_DIR}/jmx-exporter.jar ${BROKER_PLUGIN_DIR}/jmx_exporter/
-
-    mv ${SOURCES_DIR}/netty-tcnative-boringssl-static.jar ${BROKER_PLUGIN_DIR}/lib/
-    mv ${SOURCES_DIR}/netty-tcnative-boringssl-static-linux-x86_64.jar ${BROKER_PLUGIN_DIR}/lib/
+    unzip "${SOURCES_DIR}/broker-plugin.zip" -d /
 }
 
 chown -R 185:0 /home/jboss


### PR DESCRIPTION
Replaces: https://github.com/jboss-container-images/amq-online-images/pull/98

- jmx_exporter and tcnative were aready included in broker-plugin.jar, removing them from the image.yam artifact section.