### PR TITLE
Revert artifact include

### DIFF
--- a/broker-plugin/image-template.yaml
+++ b/broker-plugin/image-template.yaml
@@ -51,11 +51,11 @@ modules:
 artifacts:
     - md5: ${ARTIFACT_MD5}
       name: broker-plugin.zip
-    - md5: 4f08e57afb4088469904956237c0cf8e
+    - md5: 620d5c068e4ca408ad99c244f8706fce
       name: jmx-exporter.jar
-    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
+    - md5: 60f88be0fa76bc2d1b89f71725910441
       name: netty-tcnative-boringssl-static.jar
-    - md5: f9410ba141f63cff9202149efc321657
+    - md5: 937aaba484e64f035cc85239a1e2e184
       name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:

--- a/broker-plugin/image-template.yaml
+++ b/broker-plugin/image-template.yaml
@@ -51,6 +51,12 @@ modules:
 artifacts:
     - md5: ${ARTIFACT_MD5}
       name: broker-plugin.zip
+    - md5: 4f08e57afb4088469904956237c0cf8e
+      name: jmx-exporter.jar
+    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
+      name: netty-tcnative-boringssl-static.jar
+    - md5: f9410ba141f63cff9202149efc321657
+      name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:
       user: 185

--- a/broker-plugin/image.yaml
+++ b/broker-plugin/image.yaml
@@ -51,11 +51,11 @@ modules:
 artifacts:
     - md5: b5d4556300b6cc877d370da1b2f39d3b
       name: broker-plugin.zip
-    - md5: 4f08e57afb4088469904956237c0cf8e
+    - md5: 620d5c068e4ca408ad99c244f8706fce
       name: jmx-exporter.jar
-    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
+    - md5: 60f88be0fa76bc2d1b89f71725910441
       name: netty-tcnative-boringssl-static.jar
-    - md5: f9410ba141f63cff9202149efc321657
+    - md5: 937aaba484e64f035cc85239a1e2e184
       name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:

--- a/broker-plugin/image.yaml
+++ b/broker-plugin/image.yaml
@@ -51,6 +51,12 @@ modules:
 artifacts:
     - md5: b5d4556300b6cc877d370da1b2f39d3b
       name: broker-plugin.zip
+    - md5: 4f08e57afb4088469904956237c0cf8e
+      name: jmx-exporter.jar
+    - md5: 5da2f900047b0a53bf526dd9f37d4ffd
+      name: netty-tcnative-boringssl-static.jar
+    - md5: f9410ba141f63cff9202149efc321657
+      name: netty-tcnative-boringssl-static-linux-x86_64.jar
 
 run:
       user: 185

--- a/broker-plugin/modules/broker-plugin-installer/install.sh
+++ b/broker-plugin/modules/broker-plugin-installer/install.sh
@@ -8,8 +8,15 @@ BROKER_PLUGIN_DIR=/opt/broker-plugin
 
 {
     mkdir -p ${BROKER_PLUGIN_DIR}/bin
+    mkdir -p ${BROKER_PLUGIN_DIR}/lib
+    mkdir -p ${BROKER_PLUGIN_DIR}/jmx_exporter
 
-    unzip "${SOURCES_DIR}/broker-plugin.zip" -d /
+	unzip "${SOURCES_DIR}/broker-plugin.zip" -d /
+
+    mv ${SOURCES_DIR}/jmx-exporter.jar ${BROKER_PLUGIN_DIR}/jmx_exporter/
+
+    mv ${SOURCES_DIR}/netty-tcnative-boringssl-static.jar ${BROKER_PLUGIN_DIR}/lib/
+    mv ${SOURCES_DIR}/netty-tcnative-boringssl-static-linux-x86_64.jar ${BROKER_PLUGIN_DIR}/lib/
 }
 
 chown -R 185:0 /home/jboss


### PR DESCRIPTION
We need to include this after all. I was mistaken that these were part of the plugin. Although the dependencies try to resolve these artifacts, they are not included in the zip. Readding them for now until we figure out a better way.