### PR TITLE
use content_sets instead of repositories

### DIFF
--- a/auth-plugin/image-template.yaml
+++ b/auth-plugin/image-template.yaml
@@ -26,12 +26,6 @@ envs:
     - name: "JAVA_OPTS"
       value: "-Dvertx.cacheDirBase=/tmp -Djboss.bind.address=0.0.0.0 -Djava.net.preferIPv4Stack=true"
 
-packages:
-    repositories:
-      - jboss-os
-    install:
-      - openssl
-
 modules:
       repositories:
           - name: cct_module

--- a/auth-plugin/image.yaml
+++ b/auth-plugin/image.yaml
@@ -27,10 +27,11 @@ envs:
       value: "-Dvertx.cacheDirBase=/tmp -Djboss.bind.address=0.0.0.0 -Djava.net.preferIPv4Stack=true"
 
 packages:
-    repositories:
-      - jboss-os
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
-      - openssl
+        - openssl
 
 modules:
       repositories:

--- a/standard-controller/image-template.yaml
+++ b/standard-controller/image-template.yaml
@@ -40,8 +40,9 @@ modules:
           - name: common.java
 
 packages:
-    repositories:
-        - jboss-os
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
         - openssl
 

--- a/standard-controller/image.yaml
+++ b/standard-controller/image.yaml
@@ -40,8 +40,9 @@ modules:
           - name: common.java
 
 packages:
-    repositories:
-        - jboss-os
+    content_sets:
+        x86_64:
+            - rhel-7-server-rpms
     install:
         - openssl
 


### PR DESCRIPTION
Corrected 2 conversions of repositories to content_sets
same as https://github.com/jboss-container-images/amq-online-images/pull/102

Signed-off-by: Vanessa <vbusch@redhat.com>