### PR TITLE
Change the database name to `amqonline`

### DIFF
--- a/templates/ansible/roles/standard_authservice_postgresql/tasks/main.yml
+++ b/templates/ansible/roles/standard_authservice_postgresql/tasks/main.yml
@@ -127,7 +127,7 @@
             type: postgresql
             host: postgresql
             port: 5432
-            database: postgresql
+            database: amqonline
             credentialsSecret:
               name: postgresql
       EOF


### PR DESCRIPTION
In 1.0.x, the postgresql database name was `amqonline`. I believe this was determined by the `database-name` key in the `postgresql` secret created by the keycloak-controller.

However, the secret is now created elsewhere, and sets a value based on the `database` key here, which is hardcoded as `postgresql` now.
This causes 2 problems for us that we have to try work around.

- existing installations being upgraded from 1.0 to 1.1.1 need to patch the AuthenticationService after the upgrade to reset the database name to `amqonline`. We don't want to lose any data here, so we have to ensure it's using the same database.
- new installations of 1.1.1 need to also patch the AuthenticationService to set the database name to `amqonline` to avoid different clusters having different setups

Ideally the database name stays the same as it was before (`amqonline`).

cc @k-wall for discussion on this.