### PR TITLE
Updated for cekit 3 (3.2.0)

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -7,6 +7,7 @@ DOCKER_BUILD_OPTS?=
 DOCKER?=docker
 PRODUCT_DIR?=../../enmasse
 
+CEKIT_BUILD_ENGINE?=docker
 ifeq ($(TECH_PREVIEW),true)
 	CEKIT_BASE_ARGS=--build-tech-preview
 endif
@@ -18,7 +19,7 @@ NEW_ABSOLUTE_LOCAL_ARTIFACT?=$(ARTIFACT_CACHE_DIR)/$(NEW_ARTIFACT)
 
 all: build 
 	echo "Running docker rhel build $(REPO)"
-	cekit build --descriptor $(IMAGE_FILE) $(CEKIT_BASE_ARGS) $(CEKIT_ARGS)
+	cekit --descriptor $(IMAGE_FILE) build $(CEKIT_BUILD_ARGS) $(CEKIT_BUILD_ENGINE) $(CEKIT_ENGINE_ARGS) $(CEKIT_BASE_ARGS) 
 
 generate:
 	if [ -f image-template.yaml ]; then RELEASE_VERSION=$(RELEASE_VERSION) ARTIFACT=$(ARTIFACT) ARTIFACT_MD5=$(ARTIFACT_MD5) envsubst < image-template.yaml > image.yaml; fi

--- a/Makefile.common
+++ b/Makefile.common
@@ -9,7 +9,11 @@ PRODUCT_DIR?=../../enmasse
 
 CEKIT_BUILD_ENGINE?=docker
 ifeq ($(TECH_PREVIEW),true)
-	CEKIT_BASE_ARGS=--build-tech-preview
+	ifeq ($(CEKIT_BUILD_ENGINE), osbs)
+		CEKIT_OSBS_TECH_PREVIEW_ARGS=--tech-preview
+	else
+		CEKIT_LOCAL_TECH_PREVIEW_ARGS=--overrides "{'name': '$(REPO)'}"
+	endif
 endif
 
 NEW_ARTIFACT= $(shell echo $(LOCAL_ARTIFACT_DIR) | rev| cut -d '/' -f 1 |sed 's/\([^0-9]*[\.]\).*[0-9][-]\(.*\)/\1\2/' |rev)
@@ -19,7 +23,7 @@ NEW_ABSOLUTE_LOCAL_ARTIFACT?=$(ARTIFACT_CACHE_DIR)/$(NEW_ARTIFACT)
 
 all: build 
 	echo "Running docker rhel build $(REPO)"
-	cekit --descriptor $(IMAGE_FILE) build $(CEKIT_BUILD_ARGS) $(CEKIT_BUILD_ENGINE) $(CEKIT_ENGINE_ARGS) $(CEKIT_BASE_ARGS) 
+	cekit --descriptor $(IMAGE_FILE) build $(CEKIT_BUILD_ARGS) $(CEKIT_LOCAL_TECH_PREVIEW_ARGS) $(CEKIT_BUILD_ENGINE) $(CEKIT_ENGINE_ARGS) $(CEKIT_OSBS_TECH_PREVIEW_ARGS) 
 
 generate:
 	if [ -f image-template.yaml ]; then RELEASE_VERSION=$(RELEASE_VERSION) ARTIFACT=$(ARTIFACT) ARTIFACT_MD5=$(ARTIFACT_MD5) envsubst < image-template.yaml > image.yaml; fi


### PR DESCRIPTION
To build local docker images,  'make' works with no args.

Following args can be set for overriding:
CEKIT_BUILD_ARGS="--overrides \"{'from': 'rhel7:7.6-.....'}\""
CEKIT_BUILD_ENGINE=osbs
CEKIT_ENGINE_ARGS="--release --koji-target amq7-amq-online-1-rhel-7-containers-candidate --nowait" 

Signed-off-by: Vanessa <vbusch@redhat.com>