### PR TITLE
Fixed missing directory

### DIFF
--- a/regenerate-templates.sh
+++ b/regenerate-templates.sh
@@ -128,8 +128,7 @@ rsync --exclude '*.orig' -a ${WORKDIR}/templates/build/enmasse-${VERSION}/* ${TA
 
 rm -rf templates/docs
 
-rm -Rf templates/install/olm/amq-online
-mv templates/install/olm/enmasse templates/install/olm/amq-online
+rm templates/install/olm/amq-online/amq-online*.yaml
 pushd templates/install/olm/amq-online
 for i in $(ls *.yaml); do
 	mv "$i" "amq-online-$i"


### PR DESCRIPTION
Existing behaviour is:
- rsync copies new files from build dir to templates/install/olm/amq-online/ , 
- and these new files get prefixed with 'amq-online'
Change:
1) Add removal of the old amq-online*.yaml files before prefixing the new ones.
2) Leave the existing directory, which includes the new file.
3) Don't copy files from an enmasse dir, which isn't found.

Signed-off-by: Vanessa <vbusch@redhat.com>