### PR TITLE
Fix building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 
 SUBDIRS=\
-	templates \
 	standard-controller \
 	address-space-controller \
 	agent \


### PR DESCRIPTION
Removed templates from the subdirs that get built.  There is no makefile or targets that apply to templates.

Signed-off-by: Vanessa <vbusch@redhat.com>