### PR TITLE
Setting version of cekit to 3.2.0

### DIFF
--- a/scripts/build-images-virtual-env.sh
+++ b/scripts/build-images-virtual-env.sh
@@ -5,6 +5,6 @@
 virtualenv ~/cekit
 source ~/cekit/bin/activate
 pip install odcs
-pip install -U cekit
+pip install -U cekit==3.2.0
 make
 


### PR DESCRIPTION
The next version of cekit 3.3.1 is now available.
Need to refactor the location of the artifacts before upgrading to 3.3.1

Signed-off-by: Vanessa <vbusch@redhat.com>