### PR TITLE
Modifications for cekit 3.3.1

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -7,7 +7,7 @@ DOCKER_BUILD_OPTS?=
 DOCKER?=docker
 PRODUCT_DIR?=../../enmasse
 
-CEKIT_BUILD_ENGINE?=docker
+CEKIT_BUILD_ENGINE?=docker --no-squash
 ifeq ($(TECH_PREVIEW),true)
 	ifeq ($(CEKIT_BUILD_ENGINE), osbs)
 		CEKIT_OSBS_TECH_PREVIEW_ARGS=--tech-preview
@@ -26,6 +26,7 @@ all: build
 	cekit --descriptor $(IMAGE_FILE) build $(CEKIT_BUILD_ARGS) $(CEKIT_LOCAL_TECH_PREVIEW_ARGS) $(CEKIT_BUILD_ENGINE) $(CEKIT_ENGINE_ARGS) $(CEKIT_OSBS_TECH_PREVIEW_ARGS) 
 
 generate:
+	if [ -f modules/install-artifact/module-template.yaml ]; then ARTIFACT_MD5=$(ARTIFACT_MD5) envsubst < modules/install-artifact/module-template.yaml > modules/install-artifact/module.yaml; fi
 	if [ -f image-template.yaml ]; then RELEASE_VERSION=$(RELEASE_VERSION) ARTIFACT=$(ARTIFACT) ARTIFACT_MD5=$(ARTIFACT_MD5) envsubst < image-template.yaml > image.yaml; fi
 
 tag:
@@ -48,7 +49,7 @@ listbuildid:
 cacheartifact:
 	$(eval MD5SUM=$(shell md5sum ${ABSOLUTE_LOCAL_ARTIFACT_DIR} | cut -f 1 -d ' '))
 	cekit-cache add ${ABSOLUTE_LOCAL_ARTIFACT_DIR} --md5 ${MD5SUM}
-	sed -i 's/- md5:.*/- md5: ${MD5SUM}/' ${IMAGE_FILE}
+	sed -i 's/- md5:.*/- md5: ${MD5SUM}/' modules/install-artifact/module.yaml 
 
 clean:
 	rm -rf build target

--- a/address-space-controller/image-template.yaml
+++ b/address-space-controller/image-template.yaml
@@ -28,14 +28,15 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - name: addresscontroller.common
-            path: modules/common
+          - name: addresscontroller
+            path: modules
           - name: common.java
             path: ../modules/common/java
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: addresscontroller.install.artifact
           - name: addresscontroller.common
           - name: common.java
 
@@ -45,10 +46,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: address-space-controller.zip
 
 run:
       user: 185

--- a/address-space-controller/modules/install-artifact/module-template.yaml
+++ b/address-space-controller/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: addresscontroller.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: address-space-controller.zip

--- a/address-space-controller/modules/install-artifact/module.yaml
+++ b/address-space-controller/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: addresscontroller.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 3c2c5562c5e10f9e91f905b1bade5858
+    name: address-space-controller.zip

--- a/agent/image-template.yaml
+++ b/agent/image-template.yaml
@@ -23,13 +23,10 @@ envs:
 modules:
       repositories:
           - name: agent
-            path: modules/platform/rhel
+            path: modules
       install:
+          - name: agent.install.artifact
           - name: agent
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: agent-dist.zip
 
 ports:
     - value: 56720

--- a/agent/modules/install-artifact/module-template.yaml
+++ b/agent/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: agent.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: agent-dist.zip

--- a/agent/modules/install-artifact/module.yaml
+++ b/agent/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: agent.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 119c9f931decfd56d863ae5b4868dc7f
+    name: agent-dist.zip

--- a/api-server/image-template.yaml
+++ b/api-server/image-template.yaml
@@ -32,10 +32,13 @@ modules:
             path: modules/common
           - name: common.java
             path: ../modules/common/java
+          - name: api-server.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: api-server.install.artifact
           - name: apiserver.common
           - name: common.java
 
@@ -45,10 +48,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: api-server.jar
 
 run:
       user: 185

--- a/api-server/modules/install-artifact/module-template.yaml
+++ b/api-server/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: api-server.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: api-server.jar

--- a/api-server/modules/install-artifact/module.yaml
+++ b/api-server/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: api-server.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: b3b86b37366d412975aa585fff5e95e3
+    name: api-server.jar

--- a/auth-plugin/image-template.yaml
+++ b/auth-plugin/image-template.yaml
@@ -33,13 +33,16 @@ modules:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
           - name: auth.rhel.install
-            path: modules
+            path: modules/auth.rhel.install
           - name: common.java
             path: ../modules/common/java
+          - name: auth-plugin.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: auth-plugin.install.artifact
           - name: auth.rhel.install
           - name: common.java
 
@@ -49,10 +52,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: sasl-plugin.jar
 
 run:
       user: 185

--- a/auth-plugin/modules/install-artifact/module-template.yaml
+++ b/auth-plugin/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: auth-plugin.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: sasl-plugin.jar

--- a/auth-plugin/modules/install-artifact/module.yaml
+++ b/auth-plugin/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: auth-plugin.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: cee6370d5e6caf7a071464fe03ee3e9e
+    name: sasl-plugin.jar

--- a/broker-plugin/image-template.yaml
+++ b/broker-plugin/image-template.yaml
@@ -41,20 +41,16 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - path: modules
+          - name: broker.plugin.installer
+            path: modules
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: broker-plugin.install.artifact
           - name: broker.plugin.installer
           - name: dynamic-resources
           - name: os-java-run
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: broker-plugin.zip
-    - md5: 620d5c068e4ca408ad99c244f8706fce
-      name: jmx-exporter.jar
 
 run:
       user: 185

--- a/broker-plugin/modules/broker-plugin-installer/module.yaml
+++ b/broker-plugin/modules/broker-plugin-installer/module.yaml
@@ -6,3 +6,7 @@ version: '1.0'
 execute:
   - script: licenses.sh
   - script: install.sh
+
+artifacts:
+  - md5: 620d5c068e4ca408ad99c244f8706fce
+    name: jmx-exporter.jar

--- a/broker-plugin/modules/install-artifact/module-template.yaml
+++ b/broker-plugin/modules/install-artifact/module-template.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+
+name: broker-plugin.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: broker-plugin.zip
+  - md5: 620d5c068e4ca408ad99c244f8706fce
+    name: jmx-exporter.jar

--- a/broker-plugin/modules/install-artifact/module.yaml
+++ b/broker-plugin/modules/install-artifact/module.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+
+name: broker-plugin.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 63aa6649e663df3bd0f4409ce7d37fda
+    name: broker-plugin.zip
+  - md5: 63aa6649e663df3bd0f4409ce7d37fda
+    name: jmx-exporter.jar

--- a/console-httpd/image-template.yaml
+++ b/console-httpd/image-template.yaml
@@ -28,9 +28,10 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - name: consolehttpd.common
-            path: modules/common
+          - name: consolehttpd
+            path: modules
       install:
+          - name: console-httpd.install.artifact
           - name: jboss.container.user
           - name: consolehttpd.common
 
@@ -42,10 +43,6 @@ packages:
         - unzip
         - httpd
         - mod_ssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: console-httpd-dist.zip
 
 run:
       user: 185

--- a/console-httpd/modules/install-artifact/module-template.yaml
+++ b/console-httpd/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: console-httpd.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: console-httpd-dist.zip

--- a/console-httpd/modules/install-artifact/module.yaml
+++ b/console-httpd/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: console-httpd.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 9ad4bc7b9274a49280f614c2656331ed
+    name: console-httpd-dist.zip

--- a/console-init/image-template.yaml
+++ b/console-init/image-template.yaml
@@ -28,9 +28,10 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - name: consoleinit.common
-            path: modules/common
+          - name: consoleinit
+            path: modules
       install:
+          - name: console-init.install.artifact
           - name: consoleinit.common
 
 packages:
@@ -39,10 +40,6 @@ packages:
             - rhel-7-server-rpms
     install:
       - unzip
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: console-init-dist.zip
 
 run:
       cmd:

--- a/console-init/modules/install-artifact/module-template.yaml
+++ b/console-init/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: console-init.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: console-init-dist.zip

--- a/console-init/modules/install-artifact/module.yaml
+++ b/console-init/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: console-init.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: d7f42e834fd83b6a8d8d51d0eb5ead5c
+    name: console-init-dist.zip

--- a/controller-manager/Makefile
+++ b/controller-manager/Makefile
@@ -3,15 +3,15 @@ OLM_VER := $(shell yq r ../templates/install/olm/amq-online/amq-online.package.y
 
 include ../Makefile.common
 
-build: build/olm_manifest.tar.gz build/olm_package.tar.gz
+build: modules/olm-manifest/build/olm_manifest.tar.gz modules/olm-manifest/build/olm_package.tar.gz
 
-build/olm_manifest.tar.gz: $(wildcard ../templates/install/olm/amq-online/*.clusterserviceversion.yaml ../templates/install/olm/amq-online/*.crd.yaml)
+modules/olm-manifest/build/olm_manifest.tar.gz: $(wildcard ../templates/install/olm/amq-online/*.clusterserviceversion.yaml ../templates/install/olm/amq-online/*.crd.yaml)
 	@echo OLM_VER $(OLM_VER)
-	mkdir -p build
+	mkdir -p modules/olm-manifest/build
 	tar czf $@ --transform 's,^,$(OLM_VER)/,' -C $(<D) $(^F)
 	tar tzf $@
 
-build/olm_package.tar.gz: ../templates/install/olm/amq-online/amq-online.package.yaml
-	mkdir -p build
+modules/olm-manifest/build/olm_package.tar.gz: ../templates/install/olm/amq-online/amq-online.package.yaml
+	mkdir -p modules/olm-manifest/build
 	tar czf $@ -C $(<D) $(^F)
 	tar tzf $@

--- a/controller-manager/image-template.yaml
+++ b/controller-manager/image-template.yaml
@@ -34,10 +34,11 @@ modules:
               ref: master
           - name: common.go
             path: ../modules/common/go
-          - name: controller-manager.olm-manifest
-            path: modules/olm-manifest
+          - name: controller-manager
+            path: modules
       install:
           - name: jboss.container.user
+          - name: controller-manager.install.artifact
           - name: common.go
           - name: controller-manager.olm-manifest
 
@@ -45,11 +46,6 @@ packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: dist-bin.zip
-    - path: build/olm_manifest.tar.gz
-    - path: build/olm_package.tar.gz
 
 run:
       user: 185

--- a/controller-manager/modules/install-artifact/module-template.yaml
+++ b/controller-manager/modules/install-artifact/module-template.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+name: controller-manager.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: dist-bin.zip
+

--- a/controller-manager/modules/install-artifact/module.yaml
+++ b/controller-manager/modules/install-artifact/module.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+name: controller-manager.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 8d80ec2aff9f486e39288fd46c446d3b
+    name: dist-bin.zip
+

--- a/controller-manager/modules/olm-manifest/module.yaml
+++ b/controller-manager/modules/olm-manifest/module.yaml
@@ -5,3 +5,6 @@ version: '1.0'
 
 execute:
     - script: install.sh
+artifacts:
+    - path: build/olm_manifest.tar.gz
+    - path: build/olm_package.tar.gz

--- a/iot-auth-service/image-template.yaml
+++ b/iot-auth-service/image-template.yaml
@@ -34,10 +34,13 @@ modules:
             path: ../modules/hono/ip
           - name: hono.install
             path: ../modules/hono/install
+          - name: iot-auth-service.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: iot-auth-service.install.artifact
           - name: hono.ip
           - name: iot.java
           - name: hono.install
@@ -48,10 +51,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: iot-component.jar
 
 run:
       user: 185

--- a/iot-auth-service/modules/install-artifact/module-template.yaml
+++ b/iot-auth-service/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-auth-service.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: iot-component.jar

--- a/iot-auth-service/modules/install-artifact/module.yaml
+++ b/iot-auth-service/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-auth-service.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 6ffac4bb226fdbb80b1c72af49156619
+    name: iot-component.jar

--- a/iot-device-registry-datagrid/image-template.yaml
+++ b/iot-device-registry-datagrid/image-template.yaml
@@ -34,10 +34,13 @@ modules:
             path: ../modules/hono/ip
           - name: hono.install
             path: ../modules/hono/install
+          - name: iot-device-registry-datagrid.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: iot-device-registry-datagrid.install.artifact
           - name: hono.ip
           - name: iot.java
           - name: hono.install
@@ -48,10 +51,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: iot-component.jar
 
 run:
       user: 185

--- a/iot-device-registry-datagrid/modules/install-artifact/module-template.yaml
+++ b/iot-device-registry-datagrid/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-device-registry-datagrid.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: iot-component.jar

--- a/iot-device-registry-datagrid/modules/install-artifact/module.yaml
+++ b/iot-device-registry-datagrid/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-device-registry-datagrid.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 249e6a0e1cb7eb99b84c25a14e48873d
+    name: iot-component.jar

--- a/iot-device-registry-file/image-template.yaml
+++ b/iot-device-registry-file/image-template.yaml
@@ -34,10 +34,13 @@ modules:
             path: ../modules/hono/ip
           - name: hono.install
             path: ../modules/hono/install
+          - name: iot-device-registry-file.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: iot-device-registry-file.install.artifact
           - name: hono.ip
           - name: iot.java
           - name: hono.install
@@ -48,10 +51,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: iot-component.jar
 
 run:
       user: 185

--- a/iot-device-registry-file/modules/install-artifact/module-template.yaml
+++ b/iot-device-registry-file/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-device-registry-file.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: iot-component.jar

--- a/iot-device-registry-file/modules/install-artifact/module.yaml
+++ b/iot-device-registry-file/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-device-registry-file.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 0ffc612295044ea4b2fde5b29812e271
+    name: iot-component.jar

--- a/iot-gc/image-template.yaml
+++ b/iot-gc/image-template.yaml
@@ -30,18 +30,17 @@ modules:
               ref: master
           - name: common.go
             path: ../modules/common/go
+          - name: iot-gc.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
+          - name: iot-gc.install.artifact
           - name: common.go
 
 packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: dist-bin.zip
 
 run:
       user: 185

--- a/iot-gc/modules/install-artifact/module-template.yaml
+++ b/iot-gc/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-gc.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: dist-bin.zip

--- a/iot-gc/modules/install-artifact/module.yaml
+++ b/iot-gc/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-gc.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: d9f9af51739e52a6799db1b200e44b17
+    name: dist-bin.zip

--- a/iot-http-adapter/image-template.yaml
+++ b/iot-http-adapter/image-template.yaml
@@ -34,10 +34,13 @@ modules:
             path: ../modules/hono/ip
           - name: hono.install
             path: ../modules/hono/install
+          - name: iot-http-adapter.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: iot-http-adapter.install.artifact
           - name: hono.ip
           - name: iot.java
           - name: hono.install
@@ -48,10 +51,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: iot-component.jar
 
 run:
       user: 185

--- a/iot-http-adapter/modules/install-artifact/module-template.yaml
+++ b/iot-http-adapter/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-http-adapter.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: iot-component.jar

--- a/iot-http-adapter/modules/install-artifact/module.yaml
+++ b/iot-http-adapter/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-http-adapter.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: e1a38b63c5df852f18e354c3463807e3
+    name: iot-component.jar

--- a/iot-mqtt-adapter/image-template.yaml
+++ b/iot-mqtt-adapter/image-template.yaml
@@ -34,10 +34,13 @@ modules:
             path: ../modules/hono/ip
           - name: hono.install
             path: ../modules/hono/install
+          - name: iot-mqtt-adapter.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: iot-mqtt-adapter.install.artifact
           - name: hono.ip
           - name: iot.java
           - name: hono.install
@@ -48,10 +51,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: iot-component.jar
 
 run:
       user: 185

--- a/iot-mqtt-adapter/modules/install-artifact/module-template.yaml
+++ b/iot-mqtt-adapter/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-mqtt-adapter.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: iot-component.jar

--- a/iot-mqtt-adapter/modules/install-artifact/module.yaml
+++ b/iot-mqtt-adapter/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-mqtt-adapter.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ff0d2cf4792fa3b11aa612fdc96351d8
+    name: iot-component.jar

--- a/iot-proxy-configurator/image-template.yaml
+++ b/iot-proxy-configurator/image-template.yaml
@@ -30,8 +30,11 @@ modules:
               ref: master
           - name: common.go
             path: ../modules/common/go
+          - name: iot-proxy-configurator.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
+          - name: iot-proxy-configurator.install.artifact
           - name: common.go
 
 packages:
@@ -43,10 +46,6 @@ packages:
     install:
       - qpid-dispatch-router
       - qpid-dispatch-tools
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: dist-bin.zip
 
 run:
       user: 185

--- a/iot-proxy-configurator/modules/install-artifact/module-template.yaml
+++ b/iot-proxy-configurator/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-proxy-configurator.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: dist-bin.zip

--- a/iot-proxy-configurator/modules/install-artifact/module.yaml
+++ b/iot-proxy-configurator/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-proxy-configurator.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 00ff28e791f57f51650a15d4147dedf2
+    name: dist-bin.zip

--- a/iot-tenant-service/image-template.yaml
+++ b/iot-tenant-service/image-template.yaml
@@ -34,10 +34,13 @@ modules:
             path: ../modules/hono/ip
           - name: hono.install
             path: ../modules/hono/install
+          - name: iot-tenant-service.install.artifact
+            path: modules/install-artifact
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: iot-tenant-service.install.artifact
           - name: hono.ip
           - name: iot.java
           - name: hono.install
@@ -48,10 +51,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: iot-component.jar
 
 run:
       user: 185

--- a/iot-tenant-service/modules/install-artifact/module-template.yaml
+++ b/iot-tenant-service/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-tenant-service.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: iot-component.jar

--- a/iot-tenant-service/modules/install-artifact/module.yaml
+++ b/iot-tenant-service/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: iot-tenant-service.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 76d6fc5ab50edea88b3c753d57da5127
+    name: iot-component.jar

--- a/mqtt-gateway/image-template.yaml
+++ b/mqtt-gateway/image-template.yaml
@@ -22,15 +22,6 @@ envs:
     - name: "LOG_LEVEL"
       value: "info"
 
-modules:
-      repositories:
-          - name: common.java
-            path: ../modules/common/java
-          - name: mqtt-gateway
-            path: modules
-      install:
-          - name: mqtt-gateway
-          - name: common.java
 ports:
     - value: 1883
     - value: 8883
@@ -49,6 +40,7 @@ modules:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: mqtt-gateway.install.artifact
           - name: mqtt-gateway
           - name: common.java
 
@@ -56,10 +48,6 @@ packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: mqtt-gateway.jar
 
 run:
       user: 185

--- a/mqtt-gateway/modules/install-artifact/module-template.yaml
+++ b/mqtt-gateway/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: mqtt-gateway.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: mqtt-gateway.jar

--- a/mqtt-gateway/modules/install-artifact/module.yaml
+++ b/mqtt-gateway/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: mqtt-gateway.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: e9687b8d9626f9ce4e325753ab4b11a4
+    name: mqtt-gateway.jar

--- a/mqtt-lwt/image-template.yaml
+++ b/mqtt-lwt/image-template.yaml
@@ -36,6 +36,7 @@ modules:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: mqtt-lwt.install.artifact
           - name: mqtt-lwt
           - name: common.java
 
@@ -43,10 +44,6 @@ packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: mqtt-lwt.jar
 
 run:
       user: 185

--- a/mqtt-lwt/modules/install-artifact/module-template.yaml
+++ b/mqtt-lwt/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: mqtt-lwt.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: mqtt-lwt.jar

--- a/mqtt-lwt/modules/install-artifact/module.yaml
+++ b/mqtt-lwt/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: mqtt-lwt.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: a680cdfc47931808ff1bfbe4b573beef
+    name: mqtt-lwt.jar

--- a/none-auth-service/image-template.yaml
+++ b/none-auth-service/image-template.yaml
@@ -28,14 +28,15 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - name: noneauthservice.common
-            path: modules/common
+          - name: noneauthservice
+            path: modules
           - name: common.java
             path: ../modules/common/java
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: none-auth-service.install.artifact
           - name: noneauthservice.common
           - name: common.java
 
@@ -43,10 +44,6 @@ packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: none-authservice.jar
 
 run:
       user: 185

--- a/none-auth-service/modules/install-artifact/module-template.yaml
+++ b/none-auth-service/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: none-auth-service.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: none-authservice.jar

--- a/none-auth-service/modules/install-artifact/module.yaml
+++ b/none-auth-service/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: none-auth-service.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 84d01869b18c08c347e22b4587351716
+    name: none-authservice.jar

--- a/scripts/build-images-virtual-env.sh
+++ b/scripts/build-images-virtual-env.sh
@@ -5,6 +5,9 @@
 virtualenv ~/cekit
 source ~/cekit/bin/activate
 pip install odcs
-pip install -U cekit==3.2.0
+pip install docker-py
+pip install docker-squash
+
+pip install -U cekit
 make
 

--- a/service-broker/image-template.yaml
+++ b/service-broker/image-template.yaml
@@ -28,14 +28,15 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - name: servicebroker.common
-            path: modules/common
+          - name: servicebroker
+            path: modules
           - name: common.java
             path: ../modules/common/java
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: service-broker.install.artifact
           - name: servicebroker.common
           - name: common.java
 
@@ -43,10 +44,6 @@ packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: service-broker.jar
 
 run:
       user: 185

--- a/service-broker/modules/install-artifact/module-template.yaml
+++ b/service-broker/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: service-broker.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: service-broker.jar

--- a/service-broker/modules/install-artifact/module.yaml
+++ b/service-broker/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: service-broker.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: bb1662f9e3e787d45c6f8e5421782f42
+    name: service-broker.jar

--- a/standard-controller/image-template.yaml
+++ b/standard-controller/image-template.yaml
@@ -28,14 +28,15 @@ modules:
             git:
               url: https://github.com/jboss-openshift/cct_module.git
               ref: master
-          - name: standardcontroller.common
-            path: modules/common
+          - name: standardcontroller
+            path: modules
           - name: common.java
             path: ../modules/common/java
       install:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: standard-controller.install.artifact
           - name: standardcontroller.common
           - name: common.java
 
@@ -45,10 +46,6 @@ packages:
             - rhel-7-server-rpms
     install:
         - openssl
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: standard-controller.zip
 
 run:
       user: 185

--- a/standard-controller/modules/install-artifact/module-template.yaml
+++ b/standard-controller/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: standard-controller.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: standard-controller.zip

--- a/standard-controller/modules/install-artifact/module.yaml
+++ b/standard-controller/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: standard-controller.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 2e2a8a3b6970f40a1aeeaed6f4bf86ef
+    name: standard-controller.zip

--- a/topic-forwarder/image-template.yaml
+++ b/topic-forwarder/image-template.yaml
@@ -38,6 +38,7 @@ modules:
           - name: jboss.container.user
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: topic-forwarder.install.artifact
           - name: topic-forwarder
           - name: common.java
 
@@ -45,10 +46,6 @@ packages:
     content_sets:
         x86_64:
             - rhel-7-server-rpms
-
-artifacts:
-    - md5: ${ARTIFACT_MD5}
-      name: topic-forwarder.jar
 
 run:
       user: 185

--- a/topic-forwarder/modules/install-artifact/module-template.yaml
+++ b/topic-forwarder/modules/install-artifact/module-template.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: topic-forwarder.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: ${ARTIFACT_MD5}
+    name: topic-forwarder.jar

--- a/topic-forwarder/modules/install-artifact/module.yaml
+++ b/topic-forwarder/modules/install-artifact/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: topic-forwarder.install.artifact
+version: '1.0'
+
+artifacts:
+  - md5: 632df3fe1cc00073a02ea88d5e7473d9
+    name: topic-forwarder.jar


### PR DESCRIPTION
- the artifacts must be included in a module, before they are used.
- move local artifacts for olm manifest into the module directory.

Signed-off-by: Vanessa <vbusch@redhat.com>