### PR TITLE
Regularize the directory names in the manifest tree

### DIFF
--- a/controller-manager/Makefile
+++ b/controller-manager/Makefile
@@ -1,14 +1,13 @@
 LOCAL_ARTIFACT_DIR:=controller-manager/target/controller-manager-${VERSION}-dist.zip
-OLM_VER := $(shell yq -r .channels[0].currentCSV  ../templates/install/olm/amq-online/amq-online.package.yaml
+OLM_VER := $(shell yq -r .channels[0].currentCSV  ../templates/install/olm/amq-online/amq-online.package.yaml | sed -e 's/^amqonline\.//')
 
 include ../Makefile.common
 
 build: modules/olm-manifest/build/olm_manifest.tar.gz modules/olm-manifest/build/olm_package.tar.gz
 
 modules/olm-manifest/build/olm_manifest.tar.gz: $(wildcard ../templates/install/olm/amq-online/*.clusterserviceversion.yaml ../templates/install/olm/amq-online/*.crd.yaml)
-	@echo OLM_VER $(OLM_VER)
 	mkdir -p modules/olm-manifest/build
-	tar czf $@ --transform 's,^,$(OLM_VER)/,' -C $(<D) $(^F)
+	tar czf $@ --transform 's,^,amq-online.$(OLM_VER)/,' -C $(<D) $(^F)
 	tar tzf $@
 
 modules/olm-manifest/build/olm_package.tar.gz: ../templates/install/olm/amq-online/amq-online.package.yaml


### PR DESCRIPTION
There was an error that meant the the names in the hierarchal manifest tree were not uniform. i.e. amqonline.1.2.1 vs. amq-online.1.2.0, this change fixes the problem.  This problem has no functional impact, as the directory names are not significant, but looks surprising.

```
 docker run  --rm brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/amq7/amq-online-1-controller-manager:1.2-7 tar cf - /manifests  | tar tvf -
tar: Removing leading `/' from member names
drwxr-xr-x root/root         0 2019-07-29 15:48 manifests/
-rw-rw-r-- 1000/1000        79 2019-07-29 12:17 manifests/amq-online.package.yaml
drwxr-xr-x root/root         0 2019-07-29 15:48 manifests/amqonline.1.2.1/
-rw-rw-r-- 1000/1000     42092 2019-07-29 12:17 manifests/amqonline.1.2.1/amq-online.1.2.1.clusterserviceversion.yaml
-rw-rw-r-- 1000/1000       316 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-iotconfigs.crd.yaml
-rw-rw-r-- 1000/1000      1533 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-consoleservices.crd.yaml
-rw-rw-r-- 1000/1000      1758 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-addressplans.crd.yaml
-rw-rw-r-- 1000/1000      3287 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-brokeredinfraconfigs.crd.yaml
-rw-rw-r-- 1000/1000      5120 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-standardinfraconfigs.crd.yaml
-rw-rw-r-- 1000/1000      5599 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-authenticationservices.crd.yaml
-rw-rw-r-- 1000/1000      2100 2019-07-20 19:26 manifests/amqonline.1.2.1/amq-online-addressspaceplans.crd.yaml
drwxr-xr-x root/root         0 2019-07-29 15:48 manifests/amq-online.1.2.0/
-rw-r--r-- root/root       316 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-iotconfigs.crd.yaml
-rw-r--r-- root/root      1533 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-consoleservices.crd.yaml
-rw-r--r-- root/root      1758 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-addressplans.crd.yaml
-rw-r--r-- root/root      3287 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-brokeredinfraconfigs.crd.yaml
-rw-r--r-- root/root      5120 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-standardinfraconfigs.crd.yaml
-rw-r--r-- root/root      5599 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-authenticationservices.crd.yaml
-rw-r--r-- root/root      2100 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online-addressspaceplans.crd.yaml
-rw-r--r-- root/root     42063 2019-07-29 15:48 manifests/amq-online.1.2.0/amq-online.1.2.0.clusterserviceversion.yaml
```