### PR TITLE
For this 1.1 branch, we still need cekit 2.x

### DIFF
--- a/scripts/build-images-virtual-env.sh
+++ b/scripts/build-images-virtual-env.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-#sudo pip3 install virtualenv
+echo "cekit version = $(cekit --version)"
 
-virtualenv ~/cekit
-source ~/cekit/bin/activate
-pip install odcs
-pip install -U cekit
+
 make
 


### PR DESCRIPTION
Changed this script to use the pre-installed cekit (2.x), and not created a virtual env for 3.x

Signed-off-by: Vanessa <vbusch@redhat.com>