### PR TITLE
updated the branch override file, to point to an existing branch

### DIFF
--- a/iot-sigfox-adapter/override-dev.yaml
+++ b/iot-sigfox-adapter/override-dev.yaml
@@ -1,4 +1,4 @@
 osbs:
       repository:
             name: containers/amq-online-1
-            branch: amq7-amq-online-1-iot-sigfox-adapter-dev-rhel-7
+            branch: amq7-amq-online-1-iot-sigfox-adapter-rhel-7


### PR DESCRIPTION
Sigfox didn't get any dev branches.  Using amq7-amq-online-1, which we will never need.
LoRaWan got 2 dev branches :-)