### PR TITLE
Remove superfluous ancestor amq-online.package.yaml files

### DIFF
--- a/controller-manager/modules/olm-manifest/ancestor_manifests/amq-online.1.2.1/amq-online.package.yaml
+++ b/controller-manager/modules/olm-manifest/ancestor_manifests/amq-online.1.2.1/amq-online.package.yaml
@@ -1,4 +1,0 @@
-packageName: amq-online
-channels:
-- name: stable
-  currentCSV: amqonline.1.2.1

--- a/controller-manager/modules/olm-manifest/ancestor_manifests/amq-online.1.2.2/amq-online.package.yaml
+++ b/controller-manager/modules/olm-manifest/ancestor_manifests/amq-online.1.2.2/amq-online.package.yaml
@@ -1,4 +1,0 @@
-packageName: amq-online
-channels:
-- name: stable
-  currentCSV: amqonline.1.2.2


### PR DESCRIPTION
Files added to 1.2.1 and 1.2.2 ancestor trees by mistake.