### PR TITLE
Adding koji-target into the descriptor file

### DIFF
--- a/address-space-controller/image-template.yaml
+++ b/address-space-controller/image-template.yaml
@@ -60,3 +60,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-address-space-controller-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/agent/image-template.yaml
+++ b/agent/image-template.yaml
@@ -56,3 +56,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-agent-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/api-server/image-template.yaml
+++ b/api-server/image-template.yaml
@@ -63,3 +63,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-api-server-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/auth-plugin/image-template.yaml
+++ b/auth-plugin/image-template.yaml
@@ -66,3 +66,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-auth-plugin-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/broker-plugin/image-template.yaml
+++ b/broker-plugin/image-template.yaml
@@ -66,3 +66,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-broker-plugin-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/console-httpd/image-template.yaml
+++ b/console-httpd/image-template.yaml
@@ -57,3 +57,6 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-console-httpd-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+
+

--- a/console-init/image-template.yaml
+++ b/console-init/image-template.yaml
@@ -54,3 +54,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-console-init-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/controller-manager/image-template.yaml
+++ b/controller-manager/image-template.yaml
@@ -59,3 +59,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-controller-manager-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-device-registry-datagrid/image-template.yaml
+++ b/iot-device-registry-datagrid/image-template.yaml
@@ -64,3 +64,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-device-registry-datagrid-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-device-registry-file/image-template.yaml
+++ b/iot-device-registry-file/image-template.yaml
@@ -64,3 +64,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-device-registry-file-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-http-adapter/image-template.yaml
+++ b/iot-http-adapter/image-template.yaml
@@ -64,3 +64,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-http-adapter-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-lorawan-adapter/image-template.yaml
+++ b/iot-lorawan-adapter/image-template.yaml
@@ -64,3 +64,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-lorawan-adapter-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-mqtt-adapter/image-template.yaml
+++ b/iot-mqtt-adapter/image-template.yaml
@@ -64,3 +64,6 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-mqtt-adapter-rhel-7
+
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-proxy-configurator/image-template.yaml
+++ b/iot-proxy-configurator/image-template.yaml
@@ -60,3 +60,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-proxy-configurator-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-sigfox-adapter/image-template.yaml
+++ b/iot-sigfox-adapter/image-template.yaml
@@ -64,3 +64,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-sigfox-adapter-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/iot-tenant-service/image-template.yaml
+++ b/iot-tenant-service/image-template.yaml
@@ -64,3 +64,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-iot-tenant-service-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/mqtt-gateway/image-template.yaml
+++ b/mqtt-gateway/image-template.yaml
@@ -63,3 +63,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-mqtt-gateway-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/mqtt-lwt/image-template.yaml
+++ b/mqtt-lwt/image-template.yaml
@@ -59,3 +59,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-mqtt-lwt-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/none-auth-service/image-template.yaml
+++ b/none-auth-service/image-template.yaml
@@ -59,3 +59,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-none-auth-service-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/service-broker/image-template.yaml
+++ b/service-broker/image-template.yaml
@@ -59,3 +59,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-service-broker-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/standard-controller/image-template.yaml
+++ b/standard-controller/image-template.yaml
@@ -61,3 +61,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-standard-controller-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+

--- a/topic-forwarder/image-template.yaml
+++ b/topic-forwarder/image-template.yaml
@@ -61,3 +61,5 @@ osbs:
       repository:
             name: containers/amq-online-1
             branch: amq7-amq-online-1-topic-forwarder-rhel-7
+      koji_target: amq7-amq-online-1-rhel-7-containers-candidate
+


### PR DESCRIPTION
In cekit 3.5.0 the koji-target has been added to the descriptor file, and deprecated from the command-line arguments.
Setting koji-target in the descriptor files, so we can stop overriding it on the command-line.

We still require CEKIT_ENGINE_ARGS in the makefile for: --assume-yes, --nowait and --user.

Signed-off-by: Vanessa <vbusch@redhat.com>