### PR TITLE
Set the working dir to match the consoler-server's location

### DIFF
--- a/console-server/image.yaml
+++ b/console-server/image.yaml
@@ -44,6 +44,7 @@ packages:
 
 run:
       user: 185
+      workdir: "/"
       cmd:
           - "/console-server"
 osbs:


### PR DESCRIPTION
Fixes creating an address in the downstream console server.
The json file for address types wasn't being found.