### PR TITLE
Corrected content_sets for agent

### DIFF
--- a/agent/content_sets.yml
+++ b/agent/content_sets.yml
@@ -2,4 +2,3 @@
 x86_64:
 - rhel-7-server-rpms
 - rhel-server-rhscl-7-rpms
-- rhel-7-server-optional-rpms

--- a/agent/image.yaml
+++ b/agent/image.yaml
@@ -43,7 +43,6 @@ packages:
         x86_64:
             - rhel-7-server-rpms
             - rhel-server-rhscl-7-rpms
-            - rhel-7-server-optional-rpms
     install:
       - unzip
       - rh-nodejs10


### PR DESCRIPTION
rhel-7-server-rpms: is needed for unzip
rhel-server-rhscl-7-rpms: is needed for rh-node10
rhel-7-server-optional-rpms: is not required

Signed-off-by: Vanessa <vbusch@redhat.com>