### PR TITLE
Corrected the artifact path

### DIFF
--- a/console-server/Makefile
+++ b/console-server/Makefile
@@ -1,4 +1,4 @@
-LOCAL_ARTIFACT_DIR:=console/console-server/console-server-${VERSION}-dist.zip
+LOCAL_ARTIFACT_DIR:=console/console-server/target/console-server-${VERSION}-dist.zip
 REPO=amq7/amq-online-1-console-server-rhel7
 
 include ../Makefile.common


### PR DESCRIPTION
Updated the artifact path for the cacheartifactall tag, which caches the artifacts, and updates the MD5sum in the module.yaml files

Signed-off-by: Vanessa Busch <vbusch@redhat.com>