### PR TITLE
Released tags are deprecated and being remove Sept. 30

### DIFF
--- a/address-space-controller/image.yaml
+++ b/address-space-controller/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-address-space-controller
 description: "global component that implements an API for creating and deleting AMQ Online infrastructure instances, and modifying the address configuration per instance."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-address-space-controller-openshift-container"

--- a/agent/image.yaml
+++ b/agent/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-agent
 description: "AMQ Online console"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-agent-openshift-container"

--- a/auth-plugin/image.yaml
+++ b/auth-plugin/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-auth-plugin
 description: "AMQ Online SSO for authentication"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-auth-plugin-openshift-container"

--- a/broker-plugin/image.yaml
+++ b/broker-plugin/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-broker-plugin
 description: "AMQ Online initialization plugin image for AMQ Broker."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-broker-plugin-openshift-container"

--- a/console-init/image.yaml
+++ b/console-init/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-console-init
 description: "AMQ Online image for the AMQ Online Console Init"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-console-init-openshift-container"

--- a/console-server/image.yaml
+++ b/console-server/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-console-server-rhel7
 description: "AMQ Online Console Server"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-console-server-openshift-container"

--- a/controller-manager/image.yaml
+++ b/controller-manager/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-controller-manager-rhel7-operator
 description: "operator that manages AMQ Online infrastructure."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-controller-manager-operator-container"

--- a/iot-adapters/image.yaml
+++ b/iot-adapters/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-iot-adapters-rhel7
 description: "Standard protocol adapters for AMQ Online IoT."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-iot-adapters-openshift-container"

--- a/iot-auth-service/image.yaml
+++ b/iot-auth-service/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-iot-auth-service
 description: "The inter service authentication service for AMQ Online IoT."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-iot-auth-service-openshift-container"

--- a/iot-device-registry/image.yaml
+++ b/iot-device-registry/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-iot-device-registry-rhel7
 description: "AMQ Online IoT device registry implementations."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-iot-device-registry-openshift-container"

--- a/iot-proxy-configurator/image.yaml
+++ b/iot-proxy-configurator/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-iot-proxy-configurator
 description: "Configurator for the AMQP proxy in AMQ Online IoT."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-iot-proxy-configurator-openshift-container"

--- a/iot-tenant-cleaner/image.yaml
+++ b/iot-tenant-cleaner/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-iot-tenant-cleaner-rhel7
 description: "A component cleaning up tenant information."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-iot-tenant-cleaner-openshift-container"

--- a/iot-tenant-service/image.yaml
+++ b/iot-tenant-service/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-iot-tenant-service
 description: "A component implementating the Eclipse Hono Tenant API based on AMQ Online IoT project information."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-iot-tenant-service-openshift-container"

--- a/mqtt-gateway/image.yaml
+++ b/mqtt-gateway/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-mqtt-gateway
 description: "AMQ Online MQTT gateway"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-mqtt-gateway-openshift-container"

--- a/mqtt-lwt/image.yaml
+++ b/mqtt-lwt/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-mqtt-lwt
 description: "AMQ Online MQTT Last Will and Testament"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-mqtt-lwt-openshift-container"

--- a/none-auth-service/image.yaml
+++ b/none-auth-service/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-none-auth-service
 description: "authentication service implementation that allows any user full access."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-none-auth-service-openshift-container"

--- a/olm-manifest/image.yaml
+++ b/olm-manifest/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-controller-manager-rhel7-operator-metadata
 description: "Operator manifest for AMQ Online infrastructure."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-controller-manager-operator-metadata-container"

--- a/service-broker/image.yaml
+++ b/service-broker/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-service-broker
 description: "Global component that implements the Open Service Broker API for provisioning messaging."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-service-broker-openshift-container"

--- a/standard-controller/image.yaml
+++ b/standard-controller/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-standard-controller
 description: "global component that implements an API for creating and deleting AMQ Online infrastructure instances, and modifying the address configuration per instance."
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-standard-controller-openshift-container"

--- a/topic-forwarder/image.yaml
+++ b/topic-forwarder/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 version: 1.5
 name: amq7/amq-online-1-topic-forwarder
 description: "Message forwarder for topics in AMQ Online, currently used with the AMQ Broker broker"
-from: ubi7:7-released
+from: registry.redhat.io/ubi7/ubi
 labels:
     - name: "com.redhat.component"
       value: "amq7-amq-online-1-topic-forwarder-openshift-container"


### PR DESCRIPTION
The -released tag used in our parent image (ubi7:7-released), is being removed.
They need to be replaced with registry.redhat.io/ubi7/ubi:latest

Signed-off-by: Vanessa Busch <vbusch@redhat.com>